### PR TITLE
UsersController#index

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
 
   def index
     users = policy_scope(User)
-    @users = params[:genre_ids] ? users.joins(:preferences).where(preferences: { genre_id: params[:genre_ids] }) : users
+    @users = params[:genre_ids] ? users.includes(:preferences).where(preferences: { genre_id: params[:genre_ids] }) : users
   end
 
   def show; end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 class UsersController < ApplicationController
-  skip_before_action :authenticate_user!, only: :show
-  before_action :set_user
+  before_action :set_user, only: %i[show edit update]
+
+  def index
+    users = policy_scope(User)
+    @users = params[:genre_ids] ? users.joins(:preferences).where(preferences: { genre_id: params[:genre_ids] }) : users
+  end
 
   def show; end
 

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,0 +1,7 @@
+h1 User#index
+- @users.each do |user|
+    h3
+    = user.nickname
+    p
+    = user.city
+    = user.availability

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
 
-  resources :users, only: %i[show edit update]
+  resources :users, only: %i[index show edit update]
   resources :groups, only: [:index]
 
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UsersController, type: :controller do
     it 'renders all users' do
       get :index
       expect(response).to be_successful
-      expect(controller.instance_variable_get(:@users).size).to eq(2)
+      expect(controller.instance_variable_get(:@users).size).to eq(3)
     end
 
     it 'renders filtered users' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UsersController, type: :controller do
     end
 
     it 'renders filtered users' do
-      get :show, params: { genre_ids: Genre.all.pluck(:id) }
+      get :index, params: { genre_ids: Genre.all.pluck(:id) }
       expect(response).to be_successful
       expect(controller.instance_variable_get(:@users).size).to eq(1)
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -8,6 +8,24 @@ RSpec.describe UsersController, type: :controller do
     sign_in user
   end
 
+  describe '#index' do
+    before do
+      create(:user, :with_preference)
+    end
+
+    it 'renders all users' do
+      get :index
+      expect(response).to be_successful
+      expect(controller.instance_variable_get(:@users).size).to eq(2)
+    end
+
+    it 'renders filtered users' do
+      get :show, params: { genre_ids: Genre.all.pluck(:id) }
+      expect(response).to be_successful
+      expect(controller.instance_variable_get(:@users).size).to eq(1)
+    end
+  end
+
   describe '#show' do
     it 'renders a show page' do
       get :show, params: { id: user.id }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,4 +4,11 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@dnd.rpg" }
     password { 'password' }
   end
+
+  trait :with_preference do
+    after(:create) do |user|
+      genre = create(:genre)
+      user.genres << genre
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
 
   trait :with_preference do
     after(:create) do |user|
-      genre = create(:genre)
-      user.genres << genre
+      preference = create(:preference)
+      user.preferences << preference
     end
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UserPolicy do
 
   context 'other' do
     let(:user) { build(:user) }
-    it { should_not permit(:show) }
+    it { should permit(:show) }
     it { should_not permit(:edit) }
     it { should_not permit(:update) }
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -13,8 +13,19 @@ RSpec.describe UserPolicy do
 
   context 'other' do
     let(:user) { build(:user) }
-    it { should permit(:show) }
+    it { should_not permit(:show) }
     it { should_not permit(:edit) }
     it { should_not permit(:update) }
+  end
+
+  context 'policy scope' do
+    subject { Pundit.policy_scope!(logged_user, User) }
+
+    before do
+      create(:user)
+      create(:user)
+    end
+
+    it { expect(subject.size).to eq(2) }
   end
 end


### PR DESCRIPTION
- added index action to UsersController - to allow GMs to search for members to their party
- the index page takes a param of genre_ids which should default to the genres of the GM's party, but you can still search all users